### PR TITLE
Replace deprecated "sudo" with "become"

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart monit
   service: name=monit state=restarted
-  become: yes
+  become: True
   when: not (is_integration_test is defined and is_integration_test and
       (ansible_os_family == "RedHat" or ansible_distribution == "CentOS"))
 
@@ -9,16 +9,16 @@
 # https://issues.apache.org/jira/browse/KAFKA-1229
 - name: restart kafka
   shell: '/etc/init.d/kafka.sh stop && /etc/init.d/kafka.sh start'
-  become: yes
+  become: True
   when: not (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 
 - name: restart kafka
   shell: 'service kafka stop && service kafka start'
-  become: yes  
+  become: True
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
   
 - name: reload config
   shell: 'systemctl daemon-reload'
-  become: yes
+  become: True
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart monit
   service: name=monit state=restarted
-  become: True
+  become: yes
   when: not (is_integration_test is defined and is_integration_test and
       (ansible_os_family == "RedHat" or ansible_distribution == "CentOS"))
 
@@ -9,16 +9,16 @@
 # https://issues.apache.org/jira/browse/KAFKA-1229
 - name: restart kafka
   shell: '/etc/init.d/kafka.sh stop && /etc/init.d/kafka.sh start'
-  become: True
+  become: yes
   when: not (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 
 - name: restart kafka
   shell: 'service kafka stop && service kafka start'
-  become: True
+  become: yes
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
   
 - name: reload config
   shell: 'systemctl daemon-reload'
-  become: True
+  become: yes
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: restart monit
   service: name=monit state=restarted
-  sudo: yes
+  become: yes
   when: not (is_integration_test is defined and is_integration_test and
       (ansible_os_family == "RedHat" or ansible_distribution == "CentOS"))
 
@@ -9,16 +9,16 @@
 # https://issues.apache.org/jira/browse/KAFKA-1229
 - name: restart kafka
   shell: '/etc/init.d/kafka.sh stop && /etc/init.d/kafka.sh start'
-  sudo: yes
+  become: yes
   when: not (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 
 - name: restart kafka
   shell: 'service kafka stop && service kafka start'
-  sudo: yes  
+  become: yes  
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
   
 - name: reload config
   shell: 'systemctl daemon-reload'
-  sudo: yes
+  become: yes
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -1,7 +1,7 @@
 ########## Kafka Brokers
 
 - name: Make pid file
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   copy:
     content: ""
@@ -10,7 +10,7 @@
     force: no
 
 - name: Make log directory
-  sudo: True
+  become: True
   file:
     path: "{{kafka_log_directory}}"
     owner: "{{kafka_user}}"
@@ -18,7 +18,7 @@
     state: directory
 
 - name: Make log file
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   copy:
     content: ""
@@ -27,7 +27,7 @@
     force: no
 
 - name: Make topic log directory
-  sudo: True
+  become: True
   file:
     path: "{%if 'log_dirs' in item%}{{item.log_dirs}}{%else%}{{kafka_default_topic_log_directory_prefix}}kafka-logs-{{item.broker_id}}{%endif%}"
     owner: "{{kafka_user}}"
@@ -37,7 +37,7 @@
   with_items: "{{kafka_brokers}}"
 
 - name: Install kafka broker server config
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   template: >
     src=server.properties.j2
@@ -46,7 +46,7 @@
   notify: restart kafka
 
 - name: Install kafka systemd service
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka-systemd.service.j2
@@ -57,7 +57,7 @@
   notify: reload config
 
 - name: Install kafka init wrapper
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka-init.sh.j2
@@ -67,14 +67,14 @@
   when: not (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 
 - name: Make logs dir
-  sudo: True
+  become: True
   file:
     path: "{{kafka_install_dir}}/logs"
     owner: "{{kafka_user}}"
     state: directory
 
 - name: Make monit dir
-  sudo: True
+  become: True
   file:
     path: "{{kafka_monit_conf_dir}}"
     owner: root
@@ -82,7 +82,7 @@
     state: directory
 
 - name: Install monit config for kafka
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka.conf.j2
@@ -92,7 +92,7 @@
   when: kafka_monit_enabled
 
 - name: Uninstall monit config for kafka
-  sudo: True
+  become: True
   with_items: "{{kafka_brokers}}"
   file:
     path: "{{kafka_monit_conf_dir}}/{%if 'file_basename' in item%}{{item.file_basename}}{%else%}{{kafka_default_file_basename_prefix}}{{item.broker_id}}{%endif%}.conf"
@@ -101,7 +101,7 @@
   when: not kafka_monit_enabled
 
 - name: Make sure monit is started
-  sudo: True
+  become: True
   service: name=monit state=started
   # Does not work in CentOS7 or Fedora in CircleCI
   when: kafka_monit_enabled and (
@@ -109,12 +109,12 @@
            (ansible_os_family == "RedHat" or ansible_distribution == "CentOS")))
 
 #- name: Check service
-#  sudo: True
+#  become: True
 #  command: monit summary kafka
 #  register: kafka_status
 #  changed_when: False
 #
 #- name: Start service
-#  sudo: True
+#  become: True
 #  command: monit start kafka
 #  when: "'Running' not in kafka_status.stdout"

--- a/tasks/broker.yml
+++ b/tasks/broker.yml
@@ -1,7 +1,7 @@
 ########## Kafka Brokers
 
 - name: Make pid file
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   copy:
     content: ""
@@ -10,7 +10,7 @@
     force: no
 
 - name: Make log directory
-  become: True
+  become: yes
   file:
     path: "{{kafka_log_directory}}"
     owner: "{{kafka_user}}"
@@ -18,7 +18,7 @@
     state: directory
 
 - name: Make log file
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   copy:
     content: ""
@@ -27,7 +27,7 @@
     force: no
 
 - name: Make topic log directory
-  become: True
+  become: yes
   file:
     path: "{%if 'log_dirs' in item%}{{item.log_dirs}}{%else%}{{kafka_default_topic_log_directory_prefix}}kafka-logs-{{item.broker_id}}{%endif%}"
     owner: "{{kafka_user}}"
@@ -37,7 +37,7 @@
   with_items: "{{kafka_brokers}}"
 
 - name: Install kafka broker server config
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   template: >
     src=server.properties.j2
@@ -46,7 +46,7 @@
   notify: restart kafka
 
 - name: Install kafka systemd service
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka-systemd.service.j2
@@ -57,7 +57,7 @@
   notify: reload config
 
 - name: Install kafka init wrapper
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka-init.sh.j2
@@ -67,14 +67,14 @@
   when: not (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')
 
 - name: Make logs dir
-  become: True
+  become: yes
   file:
     path: "{{kafka_install_dir}}/logs"
     owner: "{{kafka_user}}"
     state: directory
 
 - name: Make monit dir
-  become: True
+  become: yes
   file:
     path: "{{kafka_monit_conf_dir}}"
     owner: root
@@ -82,7 +82,7 @@
     state: directory
 
 - name: Install monit config for kafka
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka.conf.j2
@@ -92,7 +92,7 @@
   when: kafka_monit_enabled
 
 - name: Uninstall monit config for kafka
-  become: True
+  become: yes
   with_items: "{{kafka_brokers}}"
   file:
     path: "{{kafka_monit_conf_dir}}/{%if 'file_basename' in item%}{{item.file_basename}}{%else%}{{kafka_default_file_basename_prefix}}{{item.broker_id}}{%endif%}.conf"
@@ -101,7 +101,7 @@
   when: not kafka_monit_enabled
 
 - name: Make sure monit is started
-  become: True
+  become: yes
   service: name=monit state=started
   # Does not work in CentOS7 or Fedora in CircleCI
   when: kafka_monit_enabled and (
@@ -109,12 +109,12 @@
            (ansible_os_family == "RedHat" or ansible_distribution == "CentOS")))
 
 #- name: Check service
-#  become: True
+#  become: yes
 #  command: monit summary kafka
 #  register: kafka_status
 #  changed_when: False
 #
 #- name: Start service
-#  become: True
+#  become: yes
 #  command: monit start kafka
 #  when: "'Running' not in kafka_status.stdout"

--- a/tasks/compat.yml
+++ b/tasks/compat.yml
@@ -1,6 +1,6 @@
 ---
 - name: install python-apt on ansible < 1.6.0 and ubuntu et al
-  become: True
+  become: yes
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import apt" ||
@@ -14,7 +14,7 @@
   changed_when: False
 
 - name: install python-pycurl on ansible < 1.6.0 and ubuntu et al
-  become: True
+  become: yes
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import pycurl" ||
@@ -28,7 +28,7 @@
   changed_when: False
 
 - name: install python2-yum on ansible <=1.9.2/fedora 24
-  become: True
+  become: yes
   raw: >
     if > /dev/null command -v yum && ! > /dev/null command -v dnf; then
        python -c "import yum" ||
@@ -40,7 +40,7 @@
   changed_when: False
 
 - name: install python2-dnf on ansible 2.1/fedora 24
-  become: True
+  become: yes
   raw: >
     if > /dev/null command -v dnf; then
        python -c "import dnf" ||
@@ -93,7 +93,7 @@
   action: "{{backcompat_pkg_mgr}} name=wget"
   register: result_wget
   until: result_wget is success
-  become: True
+  become: yes
   when: >
     (backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt")
        and wget_result is failed
@@ -106,5 +106,5 @@
   until: result_wget_dnf is success
   args:
     creates: /usr/bin/wget
-  become: True
+  become: yes
   when: backcompat_pkg_mgr == "dnf" and wget_result is failed

--- a/tasks/compat.yml
+++ b/tasks/compat.yml
@@ -1,6 +1,6 @@
 ---
 - name: install python-apt on ansible < 1.6.0 and ubuntu et al
-  become: yes
+  become: True
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import apt" ||
@@ -14,7 +14,7 @@
   changed_when: False
 
 - name: install python-pycurl on ansible < 1.6.0 and ubuntu et al
-  become: yes
+  become: True
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import pycurl" ||
@@ -28,7 +28,7 @@
   changed_when: False
 
 - name: install python2-yum on ansible <=1.9.2/fedora 24
-  become: yes
+  become: True
   raw: >
     if > /dev/null command -v yum && ! > /dev/null command -v dnf; then
        python -c "import yum" ||
@@ -40,7 +40,7 @@
   changed_when: False
 
 - name: install python2-dnf on ansible 2.1/fedora 24
-  become: yes
+  become: True
   raw: >
     if > /dev/null command -v dnf; then
        python -c "import dnf" ||
@@ -93,7 +93,7 @@
   action: "{{backcompat_pkg_mgr}} name=wget"
   register: result_wget
   until: result_wget is success
-  become: yes
+  become: True
   when: >
     (backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt")
        and wget_result is failed
@@ -106,5 +106,5 @@
   until: result_wget_dnf is success
   args:
     creates: /usr/bin/wget
-  become: yes
+  become: True
   when: backcompat_pkg_mgr == "dnf" and wget_result is failed

--- a/tasks/compat.yml
+++ b/tasks/compat.yml
@@ -1,6 +1,6 @@
 ---
 - name: install python-apt on ansible < 1.6.0 and ubuntu et al
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import apt" ||
@@ -14,7 +14,7 @@
   changed_when: False
 
 - name: install python-pycurl on ansible < 1.6.0 and ubuntu et al
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v apt-get; then
        python -c "import pycurl" ||
@@ -28,7 +28,7 @@
   changed_when: False
 
 - name: install python2-yum on ansible <=1.9.2/fedora 24
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v yum && ! > /dev/null command -v dnf; then
        python -c "import yum" ||
@@ -40,7 +40,7 @@
   changed_when: False
 
 - name: install python2-dnf on ansible 2.1/fedora 24
-  sudo: yes
+  become: yes
   raw: >
     if > /dev/null command -v dnf; then
        python -c "import dnf" ||
@@ -93,7 +93,7 @@
   action: "{{backcompat_pkg_mgr}} name=wget"
   register: result_wget
   until: result_wget is success
-  sudo: yes
+  become: yes
   when: >
     (backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt")
        and wget_result is failed
@@ -106,5 +106,5 @@
   until: result_wget_dnf is success
   args:
     creates: /usr/bin/wget
-  sudo: yes
+  become: yes
   when: backcompat_pkg_mgr == "dnf" and wget_result is failed

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -7,7 +7,7 @@
   changed_when: False
 
 - name: Create kafka user
-  become: True
+  become: yes
   user:
     name: "{{kafka_user}}"
     comment: "Kafka user"

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -7,7 +7,7 @@
   changed_when: False
 
 - name: Create kafka user
-  sudo: True
+  become: True
   user:
     name: "{{kafka_user}}"
     comment: "Kafka user"

--- a/tasks/epel.yml
+++ b/tasks/epel.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install redhat-lsb
-  become: yes
+  become: True
   register: result_redhat_lsb
   until: result_redhat_lsb is success
   yum:
@@ -15,7 +15,7 @@
   register: epel_repofile_result
 
 - name: Install EPEL repo.
-  become: yes
+  become: True
   register: result_epel_release
   until: result_epel_release is success
   yum:

--- a/tasks/epel.yml
+++ b/tasks/epel.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install redhat-lsb
-  sudo: yes
+  become: yes
   register: result_redhat_lsb
   until: result_redhat_lsb is success
   yum:
@@ -15,7 +15,7 @@
   register: epel_repofile_result
 
 - name: Install EPEL repo.
-  sudo: yes
+  become: yes
   register: result_epel_release
   until: result_epel_release is success
   yum:

--- a/tasks/epel.yml
+++ b/tasks/epel.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install redhat-lsb
-  become: True
+  become: yes
   register: result_redhat_lsb
   until: result_redhat_lsb is success
   yum:
@@ -15,7 +15,7 @@
   register: epel_repofile_result
 
 - name: Install EPEL repo.
-  become: True
+  become: yes
   register: result_epel_release
   until: result_epel_release is success
   yum:

--- a/tasks/install_package_names.yml
+++ b/tasks/install_package_names.yml
@@ -1,7 +1,7 @@
 ---
 - name: install {{package_names | join(' ')}} with default package manager
   action: "{{backcompat_pkg_mgr}} name={{item}}"
-  become: True
+  become: yes
   register: result_default
   until: result_default is success
   when: >
@@ -20,7 +20,7 @@
 # Use command since dnf was only added as a module in ansible 1.9.0
 - name: install {{package_names | join (' ')}} with dnf
   command: dnf install -y {{package_names | join(' ')}}
-  become: True
+  become: yes
   register: result_dnf
   until: result_dnf is success
   when: >

--- a/tasks/install_package_names.yml
+++ b/tasks/install_package_names.yml
@@ -1,7 +1,7 @@
 ---
 - name: install {{package_names | join(' ')}} with default package manager
   action: "{{backcompat_pkg_mgr}} name={{item}}"
-  sudo: yes
+  become: yes
   register: result_default
   until: result_default is success
   when: >
@@ -20,7 +20,7 @@
 # Use command since dnf was only added as a module in ansible 1.9.0
 - name: install {{package_names | join (' ')}} with dnf
   command: dnf install -y {{package_names | join(' ')}}
-  sudo: yes
+  become: yes
   register: result_dnf
   until: result_dnf is success
   when: >

--- a/tasks/install_package_names.yml
+++ b/tasks/install_package_names.yml
@@ -1,7 +1,7 @@
 ---
 - name: install {{package_names | join(' ')}} with default package manager
   action: "{{backcompat_pkg_mgr}} name={{item}}"
-  become: yes
+  become: True
   register: result_default
   until: result_default is success
   when: >
@@ -20,7 +20,7 @@
 # Use command since dnf was only added as a module in ansible 1.9.0
 - name: install {{package_names | join (' ')}} with dnf
   command: dnf install -y {{package_names | join(' ')}}
-  become: yes
+  become: True
   register: result_dnf
   until: result_dnf is success
   when: >

--- a/tasks/mirror.yml
+++ b/tasks/mirror.yml
@@ -1,6 +1,6 @@
 ---
 - name: Make log directory
-  become: True
+  become: yes
   file:
     path: "{{kafka_log_directory}}"
     owner: "{{kafka_user}}"
@@ -8,7 +8,7 @@
     state: directory
 
 - name: Install kafka mirror config (consumer)
-  become: True
+  become: yes
   with_items: "{{ kafka_mirrors }}"
   template: >
     src=kafka-mirror-consumer.properties.j2
@@ -16,7 +16,7 @@
     owner={{kafka_user}}
 
 - name: Install kafka mirror config (producer)
-  become: True
+  become: yes
   with_items: "{{ kafka_mirrors }}"
   template: >
     src=kafka-mirror-producer.properties.j2
@@ -24,14 +24,14 @@
     owner={{kafka_user}}
 
 - name: Install kafka mirror log4j properties
-  become: True
+  become: yes
   template: >
     src=mirror-log4j.properties.j2
     dest={{kafka_install_dir}}/config/{{kafka_default_file_basename_prefix}}mirror-log4j.properties
     owner={{kafka_user}}
 
 - name: Install kafka systemd service
-  become: True
+  become: yes
   with_items: "{{ kafka_mirrors }}"
   template: >
     src=kafka-mirror-systemd.service.j2

--- a/tasks/mirror.yml
+++ b/tasks/mirror.yml
@@ -1,6 +1,6 @@
 ---
 - name: Make log directory
-  become: yes
+  become: True
   file:
     path: "{{kafka_log_directory}}"
     owner: "{{kafka_user}}"
@@ -8,7 +8,7 @@
     state: directory
 
 - name: Install kafka mirror config (consumer)
-  become: yes
+  become: True
   with_items: "{{ kafka_mirrors }}"
   template: >
     src=kafka-mirror-consumer.properties.j2
@@ -16,7 +16,7 @@
     owner={{kafka_user}}
 
 - name: Install kafka mirror config (producer)
-  become: yes
+  become: True
   with_items: "{{ kafka_mirrors }}"
   template: >
     src=kafka-mirror-producer.properties.j2
@@ -24,14 +24,14 @@
     owner={{kafka_user}}
 
 - name: Install kafka mirror log4j properties
-  become: yes
+  become: True
   template: >
     src=mirror-log4j.properties.j2
     dest={{kafka_install_dir}}/config/{{kafka_default_file_basename_prefix}}mirror-log4j.properties
     owner={{kafka_user}}
 
 - name: Install kafka systemd service
-  become: yes
+  become: True
   with_items: "{{ kafka_mirrors }}"
   template: >
     src=kafka-mirror-systemd.service.j2

--- a/tasks/untar_kafka.yml
+++ b/tasks/untar_kafka.yml
@@ -12,7 +12,7 @@
   when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
 
 - name: Make unpack directory
-  sudo: True
+  become: True
   file:
     path: "{{kafka_tmp_unpack_dir}}"
     owner: "{{kafka_user}}"
@@ -21,20 +21,20 @@
 
 - name: Unpack kafka
   command: tar xvfoz "{{kafka_dl_tmp_dir}}/{{kafka_archive}}" --strip-components 1
-  sudo: True
+  become: True
   when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
   args:
     chdir: "{{kafka_tmp_unpack_dir}}"
 
 - name: Move into place
   command: mv {{kafka_tmp_unpack_dir}} {{kafka_install_dir}}
-  sudo: True
+  become: True
   when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
   args:
     creates: "{{kafka_install_dir}}"
 
 - name: Chown to kafka
-  sudo: True
+  become: True
   file:
     path: "{{kafka_install_dir}}"
     owner: "{{kafka_user}}"

--- a/tasks/untar_kafka.yml
+++ b/tasks/untar_kafka.yml
@@ -12,7 +12,7 @@
   when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
 
 - name: Make unpack directory
-  become: True
+  become: yes
   file:
     path: "{{kafka_tmp_unpack_dir}}"
     owner: "{{kafka_user}}"
@@ -21,20 +21,20 @@
 
 - name: Unpack kafka
   command: tar xvfoz "{{kafka_dl_tmp_dir}}/{{kafka_archive}}" --strip-components 1
-  become: True
+  become: yes
   when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
   args:
     chdir: "{{kafka_tmp_unpack_dir}}"
 
 - name: Move into place
   command: mv {{kafka_tmp_unpack_dir}} {{kafka_install_dir}}
-  become: True
+  become: yes
   when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
   args:
     creates: "{{kafka_install_dir}}"
 
 - name: Chown to kafka
-  become: True
+  become: yes
   file:
     path: "{{kafka_install_dir}}"
     owner: "{{kafka_user}}"


### PR DESCRIPTION
Replace deprecated keyword "sudo" with "become", to be compatible with newer releases of Ansible.